### PR TITLE
Doc update for python newbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You will likely never need to run this again unless you want to change the mappi
 
 # Running the script
 
-Now run `akahu_to_budget.py`
+Now run `python akahu_to_budget.py`
 
 This is the workhorse.  It connects to Akahu, gets the transactions, and then syncs them to Actual Budget and/or YNAB.
 


### PR DESCRIPTION
As a Python newb, running through the docs was pretty seemless. Great work!

Other than the committed change and things mentioned in #1, the only other thing that didn't work was running `python3.12 -m venv .venv`, presumably because I installed the latest version (3.13.1). Running python3.13.1 didn't work so I assume you have set up some shortcut or there is some magical python thing I don't know about or have installed. `py -m venv .venv` worked for me, and I would suggest this may be a better alternative to use in the docs.