### PR TITLE
Doc updates for actual budget newbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Here's a picture from my setup
 
 I use pikapods for my setup.  You can sign up here: https://actualbudget.org/docs/install/pikapods/
 
-Once you've signed up you create your budget.  If you're coming from YNAB then there's a tool: https://json-exporter-for-ynab.netlify.app/
+Once you've signed up you can set up your accounts and create your budget.  If you're coming from YNAB then there's a tool: https://json-exporter-for-ynab.netlify.app/
 
 I prefer to both have a password for my Actual Budget server AND to encrypt my data on Actual Budget.  That way even if
 someone broke into PikaPods they wouldn't get automatic access to my financial data.  The code assumes you're doing this
@@ -103,9 +103,11 @@ pip install -r requirements.txt
 
 Run `python akahu_budget_mapping.py`
 
-This will ask you a bunch of questions like 
+This lets you interactively map your bank accounts with accounts set up in Actual Budget or YNAB.
+
+It will ask you a bunch of questions like 
 ```Akahu Account: DAY TO DAY (Connection: Kiwibank)
-Here is a list of target accounts:
+Here is a list of actual accounts:
 ...
 Enter the number corresponding to the best match (or press Enter to skip):
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ someone broke into PikaPods they wouldn't get automatic access to my financial d
 too - you'll need to tweak it 
 
 Now open your budget in YNAB and click 'show advanced settings'
-![Actual Setup](documentation/actual_setup.png)
+
+![Actual Setup](documentation/actual_budget_settings.png)
 
 ## YNAB
 


### PR DESCRIPTION
I came into the setup process fresh, having only just created an Actual Budget pikapod server. Following the steps in the readme I was confused when I got to running the mapping step and received this output:

```
Akahu Account: DAY TO DAY (Connection: Kiwibank)
Here is a list of actual accounts:
(Press Enter to skip for now)
0. Mark this account as DO NOT MAP (will not ask again)
No suitable match found.
Enter the number corresponding to the best match (or press Enter to skip):
```
It wasn't clear to me from the docs or this output that the accounts that it was trying to map to were the Actual Budget accounts. I  hadn't yet set up any accounts in Actual Budget, hence why the list was empty.

I think capitalising "actual" in the output would help clear up this confusion, but I think the docs could do with some improvement in this regard too.

I also fixed a broken image in the readme while I was at it.