### PR TITLE
Add account number from Akahu when mapping accounts

### DIFF
--- a/modules/account_mapper.py
+++ b/modules/account_mapper.py
@@ -389,7 +389,7 @@ def match_accounts(
         )
 
         print(
-            f"\nAkahu Account: {akahu_name} (Connection: {akahu_account['connection']})"
+            f"\nAkahu Account: {akahu_name} (Connection: {akahu_account['connection']}, account number: {akahu_account['formatted_account']})"
         )
 
         # Show existing mapping from other system


### PR DESCRIPTION
Helps differentiate between some accounts that don't support custom naming. I have a few mortgage accounts that all show as "Home Loan", so being able to see the account number helped with mapping.