### PR TITLE
Fix AKAHU_ENDPOINT

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -33,7 +33,7 @@ for key, value in ENVs.items():
 YNAB_ENDPOINT = "https://api.ynab.com/v1/"
 YNAB_HEADERS = {"Authorization": f"Bearer {ENVs['YNAB_BEARER_TOKEN']}"}
 
-AKAHU_ENDPOINT = "https://api.akahu.io/v1/"
+AKAHU_ENDPOINT = "https://api.akahu.io/v1"
 AKAHU_HEADERS = {
     "Authorization": f"Bearer {ENVs['AKAHU_USER_TOKEN']}",
     "X-Akahu-ID": ENVs["AKAHU_APP_TOKEN"],


### PR DESCRIPTION
All of the URL building around the code is using f'{AKAHU_ENDPOINT}/accounts' style format strings, which ends up creating URLs with two slashes like this: `https://api.akahu.io/v1//accounts`

Akahu is now throwing 404 errors for these requests, so we need to either change the config value to not have the slash, or fix all of the URL building. I have chosen to fix the config.