### PR TITLE
Make env vars conditional on enabled sync targets; lazy-import openai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 *.json
 .env
+.env.*
+!.env.example
 app.log
 
 # Byte-compiled / optimized / DLL files

--- a/modules/account_mapper.py
+++ b/modules/account_mapper.py
@@ -2,11 +2,8 @@
 import json
 import logging
 from datetime import datetime
-import openai
 import os
 from fuzzywuzzy import process
-
-# OpenAI client will be initialized in functions that need it
 
 
 def is_simple_value(value):
@@ -261,6 +258,8 @@ def get_openai_match_suggestion(
     prompt += "\nPlease type the number corresponding to the best match:"
 
     try:
+        import openai
+
         client = openai.OpenAI(
             base_url=os.getenv("OPENAI_BASE_URL", None),
             api_key=os.getenv("OPENAI_API_KEY"),

--- a/modules/config.py
+++ b/modules/config.py
@@ -7,45 +7,15 @@ from dotenv import load_dotenv
 # Load environment variables with override=True to ensure .env values are used
 load_dotenv(verbose=True, override=True)
 
-# Debug logging for environment variables
+for flag in ("RUN_SYNC_TO_YNAB", "RUN_SYNC_TO_AB"):
+    if os.getenv(flag) is None:
+        raise EnvironmentError(f"Missing required environment variable: {flag}")
 
-required_envs = [
-    "ACTUAL_SERVER_URL",
-    "ACTUAL_PASSWORD",
-    "ACTUAL_ENCRYPTION_KEY",
-    "ACTUAL_SYNC_ID",
-    "AKAHU_USER_TOKEN",
-    "AKAHU_APP_TOKEN",
-    "YNAB_BEARER_TOKEN",
-    "RUN_SYNC_TO_YNAB",
-    "RUN_SYNC_TO_AB",
-]
-
-# Load environment variables into a dictionary for validation
-ENVs = {key: os.getenv(key) for key in required_envs}
-
-# Validate environment variables
-for key, value in ENVs.items():
-    if value is None:
-        raise EnvironmentError(f"Missing required environment variable: {key}")
-
-# API endpoints and headers
-YNAB_ENDPOINT = "https://api.ynab.com/v1/"
-YNAB_HEADERS = {"Authorization": f"Bearer {ENVs['YNAB_BEARER_TOKEN']}"}
-
-AKAHU_ENDPOINT = "https://api.akahu.io/v1"
-AKAHU_HEADERS = {
-    "Authorization": f"Bearer {ENVs['AKAHU_USER_TOKEN']}",
-    "X-Akahu-ID": ENVs["AKAHU_APP_TOKEN"],
-}
-
-# Load boolean flags from environment variables with defaults
-RUN_SYNC_TO_YNAB = ENVs["RUN_SYNC_TO_YNAB"].lower() == "true"
-RUN_SYNC_TO_AB = ENVs["RUN_SYNC_TO_AB"].lower() == "true"
+RUN_SYNC_TO_YNAB = os.getenv("RUN_SYNC_TO_YNAB").lower() == "true"
+RUN_SYNC_TO_AB = os.getenv("RUN_SYNC_TO_AB").lower() == "true"
 FORCE_REFRESH = os.getenv("FORCE_REFRESH", "false").lower() == "true"
 DEBUG_SYNC = os.getenv("DEBUG_SYNC", "false").lower() == "true"
 
-# Validate that at least one sync target is enabled
 if not RUN_SYNC_TO_YNAB and not RUN_SYNC_TO_AB:
     logging.error(
         "Environment variable RUN_SYNC_TO_YNAB or RUN_SYNC_TO_AB must be True."
@@ -53,3 +23,33 @@ if not RUN_SYNC_TO_YNAB and not RUN_SYNC_TO_AB:
     raise EnvironmentError(
         "Environment variable RUN_SYNC_TO_YNAB or RUN_SYNC_TO_AB must be True."
     )
+
+required_envs = ["AKAHU_USER_TOKEN", "AKAHU_APP_TOKEN"]
+if RUN_SYNC_TO_AB:
+    required_envs += [
+        "ACTUAL_SERVER_URL",
+        "ACTUAL_PASSWORD",
+        "ACTUAL_ENCRYPTION_KEY",
+        "ACTUAL_SYNC_ID",
+    ]
+if RUN_SYNC_TO_YNAB:
+    required_envs += ["YNAB_BEARER_TOKEN"]
+
+ENVs = {key: os.getenv(key) for key in required_envs}
+
+for key, value in ENVs.items():
+    if value is None:
+        raise EnvironmentError(f"Missing required environment variable: {key}")
+
+AKAHU_ENDPOINT = "https://api.akahu.io/v1"
+AKAHU_HEADERS = {
+    "Authorization": f"Bearer {ENVs['AKAHU_USER_TOKEN']}",
+    "X-Akahu-ID": ENVs["AKAHU_APP_TOKEN"],
+}
+
+YNAB_ENDPOINT = "https://api.ynab.com/v1/"
+YNAB_HEADERS = (
+    {"Authorization": f"Bearer {ENVs['YNAB_BEARER_TOKEN']}"}
+    if RUN_SYNC_TO_YNAB
+    else None
+)


### PR DESCRIPTION
## Summary

Two startup-time fixes surfaced in #19 where a user doing Akahu → Actual only (no YNAB, no OpenAI) hit blocking errors before first sync:

- **`YNAB_BEARER_TOKEN` is no longer required when `RUN_SYNC_TO_YNAB=false`.** Symmetric treatment for `ACTUAL_*` when `RUN_SYNC_TO_AB=false`. Akahu credentials and the two flag vars remain mandatory.
- **`openai` is now imported lazily** inside the function that calls the API, so the main sync path does not require the `openai` package. Users who remove it from `requirements.txt` can still run sync.
- **`.gitignore` hardened** to cover `.env.*` variant files while keeping `.env.example` tracked — useful for anyone keeping separate real/sandbox env profiles.

Partially addresses #19. Other items raised there (mapper UX when no type match, unused-feature log noise) are not covered here and remain open.

## Test plan

- [x] Config loads cleanly with `RUN_SYNC_TO_YNAB=false` and `YNAB_BEARER_TOKEN` removed from `.env` (previously raised `EnvironmentError`).
- [x] `import modules.account_mapper` no longer pulls `openai` into `sys.modules`.
- [x] Full end-to-end sync against a live Actual server still runs cleanly and exits 0 (regression check).
- [ ] Reviewer: spot-check that existing users with both sync targets enabled see no behavioural change (`modules/config.py` still produces the same `AKAHU_HEADERS` / `YNAB_HEADERS` / `ENVs` when all vars are present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)