### PR TITLE
Container hygiene: non-root, .dockerignore, EXPOSE, GHCR publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Development environment
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+
+# Version control / CI
+.git/
+.github/
+.gitignore
+
+# Editor and tool configs
+.claude/
+.vscode/
+.idea/
+.flake8
+CLAUDE.md
+
+# Local state and logs
+app.log
+*.log
+actual-budget-data/
+
+# Secrets and per-user config (must be provided at runtime)
+.env
+.env.*
+!.env.example
+akahu_budget_mapping.json
+
+# Container-build artefacts (not needed inside the image)
+Containerfile
+.dockerignore
+
+# Dev-only dependencies
+requirements_dev.txt
+
+# Repo assets not used at runtime
+documentation/
+
+# Per-user analysis artefacts
+openai_response.txt
+payee_analysis_for_openai.txt
+proposed_consolidation_rules.json
+proposed_consolidation_rules.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish container image
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix/container-hygiene-and-publish]
     tags: ['v*']
   workflow_dispatch:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish container image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish container image
 
 on:
   push:
-    branches: [main, fix/container-hygiene-and-publish]
+    branches: [main]
     tags: ['v*']
   workflow_dispatch:
 

--- a/Containerfile
+++ b/Containerfile
@@ -2,10 +2,17 @@ FROM python:3.12-alpine
 
 WORKDIR /app/
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY modules ./modules
 COPY ["README.md", "LICENSE", "*.py", "."]
 
+RUN adduser -D app && chown -R app:app /app
+USER app
+
+EXPOSE 5000
+
 ENTRYPOINT ["python", "flask_app.py"]
-CMD ["--sync"] # Default to one-off sync
+# Default to a one-off sync. Override with an empty arg to launch the webhook
+# server instead, e.g. `podman run --rm -p 5000:5000 <image> ''`.
+CMD ["--sync"]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,39 @@ There is minimal security, mostly because the webhooks don't take parameters so 
 
 NOTE TO EXISTING USERS: If you're been using akahu_to_budget.py, we have finished the migration to flask_app.py.  You will need to update your scripts.
 
+# Running in a container
+
+The repository ships a `Containerfile` (works with both `docker` and `podman`)
+and publishes an image to GitHub Container Registry on every push to `main`
+and on tagged releases:
+
+- `ghcr.io/corrin/akahu_to_budget:latest` — latest `main`
+- `ghcr.io/corrin/akahu_to_budget:v1.2.3` — specific tag
+
+You still need to provide your `.env` file and the `akahu_budget_mapping.json`
+you generated during setup. Mount them both into the container:
+
+```bash
+# One-off sync (the default)
+podman run --rm \
+  --env-file ./.env \
+  -v ./akahu_budget_mapping.json:/app/akahu_budget_mapping.json \
+  ghcr.io/corrin/akahu_to_budget:latest
+
+# Webhook server (overrides the default CMD and exposes port 5000)
+podman run --rm -p 5000:5000 \
+  --env-file ./.env \
+  -v ./akahu_budget_mapping.json:/app/akahu_budget_mapping.json \
+  ghcr.io/corrin/akahu_to_budget:latest ''
+```
+
+Substitute `docker` for `podman` if you prefer. To build locally instead of
+pulling:
+
+```bash
+podman build -t akahu_to_budget:local -f Containerfile .
+```
+
 # Running Tests
 
 There are some tests to validate the API is still working.  You can probably ignore them.


### PR DESCRIPTION
Follow-up to #18. The review on that PR flagged six non-blocking gaps; this PR knocks them all out and actually satisfies what #17 asked for (a published image at `ghcr.io/corrin/akahu_to_budget:latest`).

## Changes

**Containerfile**
- Runs as a non-root `app` user (uid 1000). Alpine's Python base runs as root by default — unnecessary for this tool and a soft red flag for anything touching finance.
- `EXPOSE 5000` documents the webhook port in image metadata.
- `pip install --no-cache-dir` shrinks the image **371 MB → 311 MB** (~16%).
- Moved the "override CMD for webhook mode" note above the `CMD` line so it's a proper comment rather than trailing garbage on the instruction.

**.dockerignore** (new)
- Keeps `.env`, `.env.*`, `akahu_budget_mapping.json`, `actual-budget-data/`, `app.log`, `.venv/`, `.git/`, etc. out of the build context. Not strictly required today — the Containerfile uses explicit `COPY`s — but prevents future footguns if anyone later adds `COPY . .`, and cuts context upload from hundreds of MB to a few.

**.github/workflows/publish.yml** (new)
- Builds the Containerfile and pushes to `ghcr.io/${{ github.repository }}` on every push to `main`, on `v*` tags, and on-demand via `workflow_dispatch`. Tags `:latest` on main, `:v1.2.3` / `:v1.2` on semver tags. This is what #17 actually asked for.

**README.md**
- New "Running in a container" section with working `podman`/`docker` invocations showing `--env-file`, the `akahu_budget_mapping.json` bind-mount, and the empty-string arg trick to enter webhook mode.

## Test plan

- [x] `podman build -f Containerfile .` succeeds in ~36 s.
- [x] Resulting image runs as `uid=1000(app)` (verified via `--entrypoint id`).
- [x] `EXPOSE 5000` and `User=app` show up in `podman inspect`.
- [x] Image still fails loud with the post-#22 missing-env error path (`OSError: Missing required environment variable: RUN_SYNC_TO_YNAB`).
- [x] Image shrank 371 MB → 311 MB.
- [x] `.dockerignore` excludes `.env`, `.venv/`, etc. from build context.
- [x] `publish.yml` parses as valid YAML.
- [ ] Reviewer: on first merge to `main` the workflow will run for real; if the GHCR push fails (usually a repo-setting / package-permission issue), visibility toggles in Settings → Packages may need adjusting.

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)