### PR TITLE
Proactively trigger Akahu refresh before each sync (closes #21)

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -14,6 +14,7 @@ from actual import Actual
 
 # Import from our modules package
 from modules.sync_handler import sync_to_ab, sync_to_ynab
+from modules.account_fetcher import trigger_akahu_refresh
 from modules.account_mapper import load_existing_mapping
 from modules.config import AKAHU_ENDPOINT, AKAHU_HEADERS
 from modules.config import RUN_SYNC_TO_AB, RUN_SYNC_TO_YNAB
@@ -90,6 +91,8 @@ def run_sync(account_ids=None, debug_mode=None):
     """
     logging.info("Starting direct sync...")
     actual_count = ynab_count = 0
+
+    trigger_akahu_refresh()
 
     _, _, _, mapping_list = load_existing_mapping()
     

--- a/modules/account_fetcher.py
+++ b/modules/account_fetcher.py
@@ -103,6 +103,30 @@ def fetch_ynab_accounts():
         raise
 
 
+def trigger_akahu_refresh():
+    """Ask Akahu to refresh all connected accounts from the banks.
+
+    Akahu refreshes from banks on its own schedule (roughly daily). Without
+    this nudge a manual sync just replays whatever Akahu already has, which
+    in practice is usually several hours stale — and the symptom reported in
+    issue #21 was exactly that.
+
+    Best-effort: on failure we warn and continue, so a flaky /refresh
+    endpoint never blocks the sync itself. Any real auth/connectivity
+    problem will surface loudly on the very next Akahu API call anyway.
+    """
+    try:
+        response = requests.post(
+            f"{AKAHU_ENDPOINT}/refresh", headers=AKAHU_HEADERS, timeout=30
+        )
+        response.raise_for_status()
+        logging.info("Triggered Akahu refresh of all connected accounts.")
+    except requests.RequestException as e:
+        logging.warning(
+            f"Akahu refresh request failed (continuing with sync): {e}"
+        )
+
+
 def get_akahu_balance(akahu_account_id, akahu_endpoint, akahu_headers):
     """Fetch the balance for an Akahu account."""
     try:

--- a/modules/webhook_handler.py
+++ b/modules/webhook_handler.py
@@ -17,7 +17,11 @@ from modules.transaction_handler import (
     load_transactions_into_ynab,
     create_adjustment_txn_ynab,
 )
-from modules.account_fetcher import get_akahu_balance, get_ynab_balance
+from modules.account_fetcher import (
+    get_akahu_balance,
+    get_ynab_balance,
+    trigger_akahu_refresh,
+)
 from modules.transaction_tester import run_transaction_tests
 
 
@@ -69,6 +73,8 @@ def create_flask_app(actual_client, mapping_list, env_vars):
         ynab_count = 0
 
         try:
+            trigger_akahu_refresh()
+
             _, _, _, mapping_list = load_existing_mapping()
 
             if RUN_SYNC_TO_AB:


### PR DESCRIPTION
## Summary

Akahu pulls from banks on its own schedule — roughly once a day. Without a nudge, running `--sync` just replays whatever Akahu already has, which in practice is usually hours or a full day stale. That's exactly the symptom in #21: sync ran cleanly, reported no new transactions, because Akahu itself hadn't been out to the bank yet. `mikegjeff` worked around it by manually `POST`ing to `/v1/refresh`.

This PR just does that for the user.

## Changes

- `modules/account_fetcher.py` — new `trigger_akahu_refresh()` helper: `POST {AKAHU_ENDPOINT}/refresh` with a 30s timeout.
- `flask_app.py` — call it at the top of `run_sync()` (CLI `--sync`).
- `modules/webhook_handler.py` — call it at the top of the `/sync` webhook.

**Fire-and-forget semantics:** on failure we log a warning and continue. Rationale: a flaky `/refresh` endpoint shouldn't block the actual sync; any genuine auth/connectivity problem will surface loudly on the very next Akahu API call a few lines later.

## Test plan

- [x] Real end-to-end run against a test Actual Budget server — log shows `INFO Triggered Akahu refresh of all connected accounts.` right after `Starting direct sync...`, followed by a normal clean sync.
- [x] Negative path via monkey-patched `requests.post` raising `ConnectionError` — produces the expected `WARNING Akahu refresh request failed (continuing with sync): ...` and returns normally.
- [ ] Reviewer: webhook path (`GET /sync`) exercised against a running webhook server. I only exercised the CLI path locally; the webhook wiring is mechanically identical (same helper, same position in the try-block) so high-confidence but not strictly verified.

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)