### PR TITLE
Mapper: make AKAHU_PUBLIC_KEY / OPENAI_API_KEY genuinely optional

### DIFF
--- a/akahu_budget_mapping.py
+++ b/akahu_budget_mapping.py
@@ -50,8 +50,6 @@ logging.info(f"Sync targets - YNAB: {RUN_SYNC_TO_YNAB}, AB: {RUN_SYNC_TO_AB}")
 required_envs = [
     'AKAHU_USER_TOKEN',
     'AKAHU_APP_TOKEN',
-    'AKAHU_PUBLIC_KEY',
-    'OPENAI_API_KEY',
 ]
 
 if RUN_SYNC_TO_AB:
@@ -158,13 +156,19 @@ def main():
     if akahu_accounts_match and actual_accounts_match and ynab_accounts_match:
         logging.info("No changes detected in Akahu, Actual, or YNAB accounts. Skipping match")
     else:
+        use_openai = bool(os.getenv("OPENAI_API_KEY"))
+        logging.info(
+            f"Match suggestions: {'OpenAI' if use_openai else 'fuzzy match'} "
+            f"(set OPENAI_API_KEY to enable OpenAI)"
+        )
+
         # Step 6: Match Akahu accounts to YNAB accounts interactively
         if RUN_SYNC_TO_YNAB:
-            new_mapping = match_accounts(new_mapping, akahu_accounts, ynab_accounts, "ynab", use_openai=True)
+            new_mapping = match_accounts(new_mapping, akahu_accounts, ynab_accounts, "ynab", use_openai=use_openai)
 
         # Step 5: Match Akahu accounts to Actual accounts interactively
         if RUN_SYNC_TO_AB:
-            new_mapping = match_accounts(new_mapping, akahu_accounts, actual_accounts, "actual", use_openai=True)
+            new_mapping = match_accounts(new_mapping, akahu_accounts, actual_accounts, "actual", use_openai=use_openai)
 
     # Step 7: Save the final mapping
     data_to_save = {

--- a/modules/account_mapper.py
+++ b/modules/account_mapper.py
@@ -287,7 +287,9 @@ def get_openai_match_suggestion(
         if chosen_index is not None:
             return chosen_index
     except Exception as e:
-        logging.error(f"OpenAI API call failed or gave an invalid response: {str(e)}")
+        logging.warning(
+            f"OpenAI match suggestion unavailable ({e}); falling back to fuzzy match."
+        )
 
     return get_fuzzy_match_suggestion(
         akahu_account, target_accounts, akahu_to_account_mapping, target_account_key


### PR DESCRIPTION
## Summary

Follow-up to #22. Covers the remaining actionable items from #19 that were specific to the interactive mapping script.

### Before

- `akahu_budget_mapping.py` forced every user to set `AKAHU_PUBLIC_KEY` and `OPENAI_API_KEY` (both documented as optional). Workaround: add empty strings to `.env`. Reporter in #19 had to do exactly that.
- `match_accounts(..., use_openai=True)` was hard-coded, so users without a real OpenAI key got an `HTTP 401 Unauthorized` error per account being mapped.
- The OpenAI exception path logged at `ERROR`, which made every no-key run look like a disaster.

### After

- `required_envs` in the mapping script now lists only `AKAHU_USER_TOKEN` and `AKAHU_APP_TOKEN` (the two genuinely-required things). OpenAI and `AKAHU_PUBLIC_KEY` drop off.
- `use_openai` is computed as `bool(os.getenv("OPENAI_API_KEY"))`. No key → no OpenAI call → no 401 noise → straight to fuzzy matching. A single info log announces which mode is active.
- When OpenAI IS configured but an individual call fails, the exception is now `WARNING` with `"... falling back to fuzzy match."` rather than `ERROR`.

## Not covered (deliberately)

- `ZIP layout / No module named 'modules'` — a bad-download workflow issue, not a repo bug.
- `macOS TextEdit smart quotes in .env` — user workflow; could be a README note in a future doc PR.
- `YNAB ERROR when features disabled` — the one remaining YNAB error in `fetch_ynab_accounts` only fires when `RUN_SYNC_TO_YNAB=true` AND `YNAB_BUDGET_ID` is unset, which is a legitimate config error that should surface loudly.
- `Empty target-list when no type match` — current code shows all open accounts with no type filter, so this isn't present anymore.

## Test plan

- [x] Loaded the mapping script's env logic with `OPENAI_API_KEY` and `AKAHU_PUBLIC_KEY` unset — no `EnvironmentError`.
- [x] `bool(os.getenv("OPENAI_API_KEY"))` returns `False` when the key is absent → fuzzy mode is selected.
- [x] Simulated an OpenAI HTTP 401 via monkey-patching — confirmed `WARNING OpenAI match suggestion unavailable (...); falling back to fuzzy match.` is logged and the fuzzy fallback returns a valid result.
- [ ] Reviewer: end-to-end run of `python akahu_budget_mapping.py` in the real interactive flow. My tests are unit-level; the on-screen UX itself wasn't re-walked.

Partially addresses #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)