### PR TITLE
Surface actionable context on sync errors (helps diagnose #14)

### DIFF
--- a/modules/transaction_handler.py
+++ b/modules/transaction_handler.py
@@ -214,9 +214,15 @@ def load_transactions_into_actual(transactions, mapping_entry, actual, debug_mod
         transaction_date = txn.get("date")
         payee_name = txn.get("description")
         notes = txn.get("description")
-        amount = decimal.Decimal(txn.get("amount"))
-        amount = amount.quantize(decimal.Decimal("0.0001"))
         imported_id = txn.get("_id")
+        raw_amount = txn.get("amount")
+        try:
+            amount = decimal.Decimal(raw_amount).quantize(decimal.Decimal("0.0001"))
+        except (decimal.InvalidOperation, TypeError, ValueError) as e:
+            raise RuntimeError(
+                f"Could not parse amount={raw_amount!r} for Akahu transaction "
+                f"{imported_id} (date={transaction_date}, payee={payee_name!r})"
+            ) from e
         cleared = True
 
         try:

--- a/modules/webhook_handler.py
+++ b/modules/webhook_handler.py
@@ -87,12 +87,14 @@ def create_flask_app(actual_client, mapping_list, env_vars):
             return generate_sync_report(mapping_list, actual_count, ynab_count)
 
         except Exception as e:
-            logging.error(f"Sync failed: {str(e)}")
+            logging.exception("Sync failed")
             return (
                 jsonify(
                     {
                         "status": "error",
-                        "error": str(e),
+                        "error_type": type(e).__name__,
+                        "error": str(e) or repr(e),
+                        "hint": "Full traceback in app.log",
                     }
                 ),
                 500,


### PR DESCRIPTION
## Why

Issue #14 is underspecified because the reporter literally couldn't get any more info out of the tool. The webhook response on failure was:

\`\`\`json
{"error":"[<class 'decimal.ConversionSyntax'>]","status":"error"}
\`\`\`

That error body is \`str()\` of a raw \`decimal.InvalidOperation\` — the decimal module formats it as its own useless repr. No stack trace, no offending transaction ID, no amount value, no hint where in the sync it happened. If another user hits this tomorrow we'd be in the same spot.

This PR doesn't fix #14 directly (we still don't know what triggered it), but it ensures the **next** person who hits it gets something diagnosable.

## Changes

### `modules/webhook_handler.py`
- Swap \`logging.error(f"Sync failed: {str(e)}")\` for \`logging.exception("Sync failed")\` so the full traceback lands in \`app.log\`.
- Richer JSON body: \`error_type\` (the exception class name — e.g. \`"InvalidOperation"\` vs \`"RuntimeError"\` vs \`"AuthorizationError"\`), \`error\` (falls back to \`repr(e)\` when \`str(e)\` is empty, as happens with bare Decimal exceptions), and a \`hint\` pointing at \`app.log\`.

### `modules/transaction_handler.py`
- The bare \`amount = decimal.Decimal(txn.get("amount"))\` in \`load_transactions_into_actual\` is now wrapped.
- On \`InvalidOperation\` / \`TypeError\` / \`ValueError\` we raise a \`RuntimeError\` naming the offending Akahu transaction ID, the raw amount value (\`!r\`-quoted so \`None\` vs \`""\` vs \`"abc"\` is distinguishable), date, and payee. Original exception chained via \`from e\`, so the traceback still points at the Decimal call site.
- The \`imported_id\` lookup moved up so it's available when the error fires.

Importantly: the raise is kept. Previously the sync would have aborted with an un-contextualised exception; now it aborts with a contextualised one. Financial-data integrity > sync throughput.

## Test plan

- [x] Fed \`None\`, \`'abc'\`, \`''\`, \`{'x': 1}\` into the Decimal block — each produces a \`RuntimeError\` with the exact offending value and the Akahu transaction id in the message.
- [x] Normal values (\`-23.99\`, \`'10.50'\`, \`0\`, \`1000\`) still parse cleanly.
- [x] \`NaN\` also parses (valid Decimal input) — if it later trips up actualpy the error will surface there with its own context; not this PR's concern.
- [ ] Reviewer: poke the webhook once in a real environment to confirm the JSON shape and the \`logging.exception\` traceback in \`app.log\`. Local tests are unit-level only.

Helps #14 — leaving the issue open until an actual reproduction surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)