### PR TITLE
[codex] add HAOS mapping JSON option

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}-haos
           tags: |
-            type=raw,value=0.1.0
+            type=raw,value=0.1.1
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push HAOS add-on image
@@ -67,7 +67,7 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            BUILD_VERSION=0.1.0
+            BUILD_VERSION=0.1.1
           push: true
           tags: ${{ steps.haos_meta.outputs.tags }}
           labels: ${{ steps.haos_meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM=python:3.12-alpine
 FROM $BUILD_FROM
-ARG BUILD_VERSION=0.1.0
+ARG BUILD_VERSION=0.1.1
 
 LABEL \
     io.hass.version="${BUILD_VERSION}" \
@@ -17,6 +17,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY modules ./modules
 COPY sync_cli.py .
 COPY sure_client.py .
+COPY haos_mapping_bootstrap.py .
 
 COPY run.sh /run.sh
 RUN chmod +x /run.sh

--- a/README.md
+++ b/README.md
@@ -221,17 +221,24 @@ the Home Assistant app store by adding this repository as an app repository.
    If you place the file somewhere else, update the `mapping_file` option to
    match that path.
 
-   For automation or MCP-driven setup, you can instead paste a compressed
-   one-time copy into the `mapping_json_gzip_base64` option:
+   For automation or MCP-driven setup, you can instead paste a one-time copy
+   into the `mapping_json` option. In the YAML options editor, a block scalar
+   is easiest:
 
-   ```bash
-   gzip -c akahu_budget_mapping.json | base64 -w0
+   ```yaml
+   mapping_json: |-
+     {
+       "akahu_accounts": {},
+       "actual_accounts": {},
+       "ynab_accounts": {},
+       "mapping": {}
+     }
    ```
 
    On startup, the add-on writes that value to `mapping_file` only if the
    mapping file is missing. After the first successful start, clear
-   `mapping_json_gzip_base64` from the add-on options so the mapping is not
-   stored in Supervisor options longer than necessary.
+   `mapping_json` from the add-on options so the mapping is not stored in
+   Supervisor options longer than necessary.
 
 5. Fill in the app options for the services you use:
 
@@ -258,9 +265,9 @@ The default `sync_interval` is `86400`, which means one sync per day. Set
 `log_file` to an empty string to use Supervisor logs only; that is the default
 for the add-on.
 
-`mapping_json_gzip_base64` is optional and intended for automation. It is a
-gzip-compressed, base64-encoded copy of `akahu_budget_mapping.json`. The add-on
-uses it only when `mapping_file` does not already exist.
+`mapping_json` is optional and intended for automation or copy/paste setup. It
+is the raw contents of `akahu_budget_mapping.json`. The add-on uses it only when
+`mapping_file` does not already exist.
 
 The add-on fails loudly if the mapping file is missing or if required options
 for the enabled sync target are blank.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ repo root so it shares the same sync code as the other deployment methods.
 
 ## HAOS setup
 
+This is a Home Assistant OS app/add-on, not a HACS integration. Install it from
+the Home Assistant app store by adding this repository as an app repository.
+
 1. Generate `akahu_budget_mapping.json` before installing the add-on:
 
    ```bash
@@ -188,16 +191,24 @@ repo root so it shares the same sync code as the other deployment methods.
    This is still an interactive setup step and is easier to run on your normal
    computer than inside Home Assistant.
 
-2. In Home Assistant, go to **Settings → Apps**.
-3. Select **Install app** to open the App Store.
-4. Open the top-right store menu, choose **Repositories**, and add this repository:
+2. Add this repository to Home Assistant:
+
+   [Add Akahu to Budget repository to Home Assistant](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fcorrin%2Fakahu_to_budget)
+
+   If the direct link does not work, add it manually:
+
+   1. In Home Assistant, go to **Settings → Apps**.
+   2. Select **App store** or **Install app**.
+   3. Open the top-right `...` menu in the app store.
+   4. Choose **Repositories**.
+   5. Add this repository URL:
 
    ```text
    https://github.com/corrin/akahu_to_budget
    ```
 
-5. Install the **Akahu to Budget** app.
-6. Copy `akahu_budget_mapping.json` into the app config directory and leave
+3. Install the **Akahu to Budget** app.
+4. Copy `akahu_budget_mapping.json` into the app config directory and leave
    the default add-on option as:
 
    ```text
@@ -207,7 +218,7 @@ repo root so it shares the same sync code as the other deployment methods.
    If you place the file somewhere else, update the `mapping_file` option to
    match that path.
 
-7. Fill in the app options for the services you use:
+5. Fill in the app options for the services you use:
 
    - `RUN_SYNC_TO_AB`
    - `RUN_SYNC_TO_YNAB`
@@ -216,7 +227,7 @@ repo root so it shares the same sync code as the other deployment methods.
    - YNAB settings, if enabled
    - Sure Finance settings, if enabled
 
-8. Start the app and check the app log. It should print the options file,
+6. Start the app and check the app log. It should print the options file,
    mapping file, and sync interval before the first sync starts.
 
 ## HAOS options

--- a/README.md
+++ b/README.md
@@ -208,8 +208,11 @@ the Home Assistant app store by adding this repository as an app repository.
    ```
 
 3. Install the **Akahu to Budget** app.
-4. Copy `akahu_budget_mapping.json` into the app config directory and leave
-   the default add-on option as:
+4. Place `akahu_budget_mapping.json` where the add-on can read it.
+
+   For most people, the clearest option is to copy the file into this add-on's
+   config directory with a Home Assistant file tool such as Studio Code Server
+   or File Editor, then leave the default add-on option as:
 
    ```text
    /config/akahu_budget_mapping.json
@@ -217,6 +220,18 @@ the Home Assistant app store by adding this repository as an app repository.
 
    If you place the file somewhere else, update the `mapping_file` option to
    match that path.
+
+   For automation or MCP-driven setup, you can instead paste a compressed
+   one-time copy into the `mapping_json_gzip_base64` option:
+
+   ```bash
+   gzip -c akahu_budget_mapping.json | base64 -w0
+   ```
+
+   On startup, the add-on writes that value to `mapping_file` only if the
+   mapping file is missing. After the first successful start, clear
+   `mapping_json_gzip_base64` from the add-on options so the mapping is not
+   stored in Supervisor options longer than necessary.
 
 5. Fill in the app options for the services you use:
 
@@ -242,6 +257,10 @@ the mapping file at:
 The default `sync_interval` is `86400`, which means one sync per day. Set
 `log_file` to an empty string to use Supervisor logs only; that is the default
 for the add-on.
+
+`mapping_json_gzip_base64` is optional and intended for automation. It is a
+gzip-compressed, base64-encoded copy of `akahu_budget_mapping.json`. The add-on
+uses it only when `mapping_file` does not already exist.
 
 The add-on fails loudly if the mapping file is missing or if required options
 for the enabled sync target are blank.

--- a/akahu_to_budget_addon/DOCS.md
+++ b/akahu_to_budget_addon/DOCS.md
@@ -16,15 +16,21 @@ repo root so this wrapper does not carry a separate copy of the sync code.
    - For normal UI setup, copy it into this add-on's config directory with
      Studio Code Server, File Editor, or another Home Assistant file tool, then
      leave `mapping_file` as `/config/akahu_budget_mapping.json`.
-   - For automation or MCP-driven setup, paste a one-time compressed copy into
-     `mapping_json_gzip_base64`:
+   - For automation or MCP-driven setup, paste a one-time copy into
+     `mapping_json`:
 
-     ```bash
-     gzip -c akahu_budget_mapping.json | base64 -w0
+     ```yaml
+     mapping_json: |-
+       {
+         "akahu_accounts": {},
+         "actual_accounts": {},
+         "ynab_accounts": {},
+         "mapping": {}
+       }
      ```
 
      The add-on writes this value to `mapping_file` only if the mapping file is
-     missing. Clear `mapping_json_gzip_base64` after the first successful start.
+     missing. Clear `mapping_json` after the first successful start.
 3. Fill in the add-on options for Akahu and the enabled budget target.
 4. Start the add-on and watch the Supervisor log.
 

--- a/akahu_to_budget_addon/DOCS.md
+++ b/akahu_to_budget_addon/DOCS.md
@@ -12,8 +12,19 @@ repo root so this wrapper does not carry a separate copy of the sync code.
 
 1. Generate `akahu_budget_mapping.json` outside Home Assistant with the normal
    `python akahu_budget_mapping.py` workflow.
-2. Copy that file into this add-on's config directory, or set `mapping_file` to
-   the path where you placed it.
+2. Place that file where the add-on can read it.
+   - For normal UI setup, copy it into this add-on's config directory with
+     Studio Code Server, File Editor, or another Home Assistant file tool, then
+     leave `mapping_file` as `/config/akahu_budget_mapping.json`.
+   - For automation or MCP-driven setup, paste a one-time compressed copy into
+     `mapping_json_gzip_base64`:
+
+     ```bash
+     gzip -c akahu_budget_mapping.json | base64 -w0
+     ```
+
+     The add-on writes this value to `mapping_file` only if the mapping file is
+     missing. Clear `mapping_json_gzip_base64` after the first successful start.
 3. Fill in the add-on options for Akahu and the enabled budget target.
 4. Start the add-on and watch the Supervisor log.
 

--- a/akahu_to_budget_addon/config.yaml
+++ b/akahu_to_budget_addon/config.yaml
@@ -2,7 +2,7 @@ name: Akahu to Budget
 slug: akahu_to_budget
 description: Personal scheduled Akahu to Actual Budget/YNAB sync.
 url: https://github.com/corrin/akahu_to_budget
-version: "0.1.0"
+version: "0.1.1"
 image: ghcr.io/corrin/akahu_to_budget-haos
 stage: experimental
 startup: application
@@ -33,6 +33,7 @@ options:
   FORCE_REFRESH: false
   DEBUG_SYNC: false
   mapping_file: /config/akahu_budget_mapping.json
+  mapping_json_gzip_base64: ""
   log_file: ""
   # Akahu is synced daily in this personal HAOS deployment.
   sync_interval: 86400
@@ -56,5 +57,6 @@ schema:
   FORCE_REFRESH: bool
   DEBUG_SYNC: bool
   mapping_file: str
+  mapping_json_gzip_base64: password?
   log_file: str
   sync_interval: int(1,)

--- a/akahu_to_budget_addon/config.yaml
+++ b/akahu_to_budget_addon/config.yaml
@@ -33,7 +33,7 @@ options:
   FORCE_REFRESH: false
   DEBUG_SYNC: false
   mapping_file: /config/akahu_budget_mapping.json
-  mapping_json_gzip_base64: ""
+  mapping_json: ""
   log_file: ""
   # Akahu is synced daily in this personal HAOS deployment.
   sync_interval: 86400
@@ -57,6 +57,6 @@ schema:
   FORCE_REFRESH: bool
   DEBUG_SYNC: bool
   mapping_file: str
-  mapping_json_gzip_base64: password?
+  mapping_json: password?
   log_file: str
   sync_interval: int(1,)

--- a/haos_mapping_bootstrap.py
+++ b/haos_mapping_bootstrap.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import base64
-import binascii
-import gzip
 import json
 import os
 from pathlib import Path
@@ -12,7 +9,7 @@ from pathlib import Path
 
 DEFAULT_MAPPING_FILE = "/config/akahu_budget_mapping.json"
 DEFAULT_OPTIONS_FILE = "/data/options.json"
-MAPPING_UPLOAD_OPTION = "mapping_json_gzip_base64"
+MAPPING_UPLOAD_OPTION = "mapping_json"
 REQUIRED_MAPPING_KEYS = {
     "akahu_accounts",
     "actual_accounts",
@@ -32,19 +29,7 @@ def _load_options(options_file: str | os.PathLike[str]) -> dict:
 
 def _decode_mapping(upload_value: str) -> dict:
     try:
-        compressed = base64.b64decode(upload_value, validate=True)
-    except binascii.Error as e:
-        raise ValueError(f"{MAPPING_UPLOAD_OPTION} is not valid base64") from e
-
-    try:
-        raw = gzip.decompress(compressed)
-    except OSError as e:
-        raise ValueError(f"{MAPPING_UPLOAD_OPTION} is not valid gzip data") from e
-
-    try:
-        data = json.loads(raw.decode("utf-8"))
-    except UnicodeDecodeError as e:
-        raise ValueError(f"{MAPPING_UPLOAD_OPTION} is not UTF-8 encoded JSON") from e
+        data = json.loads(upload_value)
     except json.JSONDecodeError as e:
         raise ValueError(f"{MAPPING_UPLOAD_OPTION} does not contain valid JSON: {e}") from e
 

--- a/haos_mapping_bootstrap.py
+++ b/haos_mapping_bootstrap.py
@@ -1,0 +1,100 @@
+"""Prepare the HAOS mapping file from Supervisor options when requested."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import gzip
+import json
+import os
+from pathlib import Path
+
+
+DEFAULT_MAPPING_FILE = "/config/akahu_budget_mapping.json"
+DEFAULT_OPTIONS_FILE = "/data/options.json"
+MAPPING_UPLOAD_OPTION = "mapping_json_gzip_base64"
+REQUIRED_MAPPING_KEYS = {
+    "akahu_accounts",
+    "actual_accounts",
+    "ynab_accounts",
+    "mapping",
+}
+
+
+def _load_options(options_file: str | os.PathLike[str]) -> dict:
+    path = Path(options_file)
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Options file {path} must contain a JSON object")
+    return data
+
+
+def _decode_mapping(upload_value: str) -> dict:
+    try:
+        compressed = base64.b64decode(upload_value, validate=True)
+    except binascii.Error as e:
+        raise ValueError(f"{MAPPING_UPLOAD_OPTION} is not valid base64") from e
+
+    try:
+        raw = gzip.decompress(compressed)
+    except OSError as e:
+        raise ValueError(f"{MAPPING_UPLOAD_OPTION} is not valid gzip data") from e
+
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except UnicodeDecodeError as e:
+        raise ValueError(f"{MAPPING_UPLOAD_OPTION} is not UTF-8 encoded JSON") from e
+    except json.JSONDecodeError as e:
+        raise ValueError(f"{MAPPING_UPLOAD_OPTION} does not contain valid JSON: {e}") from e
+
+    if not isinstance(data, dict):
+        raise ValueError("Uploaded mapping must contain a JSON object")
+
+    missing_keys = REQUIRED_MAPPING_KEYS - data.keys()
+    if missing_keys:
+        missing = ", ".join(sorted(missing_keys))
+        raise ValueError(f"Uploaded mapping is missing required keys: {missing}")
+
+    return data
+
+
+def write_mapping_from_options(
+    *,
+    options_file: str | os.PathLike[str] = DEFAULT_OPTIONS_FILE,
+) -> bool:
+    """Write the mapping file from HAOS options only when the file is missing."""
+    options = _load_options(options_file)
+    mapping_file = Path(options.get("mapping_file") or DEFAULT_MAPPING_FILE)
+    upload_value = str(options.get(MAPPING_UPLOAD_OPTION) or "").strip()
+
+    if mapping_file.exists():
+        print(f"Mapping file already exists: {mapping_file}")
+        return False
+
+    if not upload_value:
+        print(f"No {MAPPING_UPLOAD_OPTION} option provided.")
+        return False
+
+    mapping_data = _decode_mapping(upload_value)
+    mapping_file.parent.mkdir(parents=True, exist_ok=True)
+    with mapping_file.open("w", encoding="utf-8") as f:
+        json.dump(mapping_data, f, indent=4)
+        f.write("\n")
+    mapping_file.chmod(0o600)
+    print(f"Mapping file created from Home Assistant options: {mapping_file}")
+    return True
+
+
+def main() -> int:
+    options_file = os.getenv("AKAHU_TO_BUDGET_OPTIONS_FILE", DEFAULT_OPTIONS_FILE)
+    try:
+        write_mapping_from_options(options_file=options_file)
+    except Exception as e:
+        print(f"ERROR: Failed to prepare mapping file: {e}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/run.sh
+++ b/run.sh
@@ -33,6 +33,8 @@ export AKAHU_TO_BUDGET_OPTIONS_FILE="$OPTIONS_FILE"
 MAPPING_FILE=$(jq -r '.mapping_file // "/config/akahu_budget_mapping.json"' "$OPTIONS_FILE")
 SYNC_INTERVAL=$(jq -r '.sync_interval // 86400' "$OPTIONS_FILE")
 
+python /app/haos_mapping_bootstrap.py
+
 if [ ! -f "$MAPPING_FILE" ]; then
     echo "ERROR: Mapping file not found: $MAPPING_FILE"
     echo "Create it with akahu_budget_mapping.py outside HAOS, then place it at the configured path."

--- a/tests/test_haos_mapping_bootstrap.py
+++ b/tests/test_haos_mapping_bootstrap.py
@@ -1,5 +1,3 @@
-import base64
-import gzip
 import json
 
 import pytest
@@ -19,9 +17,8 @@ def _mapping():
     }
 
 
-def _encoded_mapping(data=None):
-    raw = json.dumps(data or _mapping()).encode("utf-8")
-    return base64.b64encode(gzip.compress(raw)).decode("ascii")
+def _mapping_json(data=None):
+    return json.dumps(data or _mapping())
 
 
 def _write_options(path, mapping_file, **extra):
@@ -47,7 +44,7 @@ def test_valid_upload_writes_mapping_file(tmp_path):
     _write_options(
         options_file,
         mapping_file,
-        **{MAPPING_UPLOAD_OPTION: _encoded_mapping()},
+        **{MAPPING_UPLOAD_OPTION: _mapping_json()},
     )
 
     assert write_mapping_from_options(options_file=options_file) is True
@@ -63,37 +60,17 @@ def test_existing_mapping_file_is_not_overwritten(tmp_path):
     _write_options(
         options_file,
         mapping_file,
-        **{MAPPING_UPLOAD_OPTION: _encoded_mapping()},
+        **{MAPPING_UPLOAD_OPTION: _mapping_json()},
     )
 
     assert write_mapping_from_options(options_file=options_file) is False
     assert json.loads(mapping_file.read_text(encoding="utf-8")) == existing
 
 
-def test_invalid_base64_fails(tmp_path):
-    options_file = tmp_path / "options.json"
-    mapping_file = tmp_path / "akahu_budget_mapping.json"
-    _write_options(options_file, mapping_file, **{MAPPING_UPLOAD_OPTION: "not base64"})
-
-    with pytest.raises(ValueError, match="not valid base64"):
-        write_mapping_from_options(options_file=options_file)
-
-
-def test_invalid_gzip_fails(tmp_path):
-    options_file = tmp_path / "options.json"
-    mapping_file = tmp_path / "akahu_budget_mapping.json"
-    encoded = base64.b64encode(b"not gzip").decode("ascii")
-    _write_options(options_file, mapping_file, **{MAPPING_UPLOAD_OPTION: encoded})
-
-    with pytest.raises(ValueError, match="not valid gzip"):
-        write_mapping_from_options(options_file=options_file)
-
-
 def test_invalid_json_fails(tmp_path):
     options_file = tmp_path / "options.json"
     mapping_file = tmp_path / "akahu_budget_mapping.json"
-    encoded = base64.b64encode(gzip.compress(b"{not-json")).decode("ascii")
-    _write_options(options_file, mapping_file, **{MAPPING_UPLOAD_OPTION: encoded})
+    _write_options(options_file, mapping_file, **{MAPPING_UPLOAD_OPTION: "{not-json"})
 
     with pytest.raises(ValueError, match="valid JSON"):
         write_mapping_from_options(options_file=options_file)
@@ -107,7 +84,7 @@ def test_missing_required_mapping_key_fails(tmp_path):
     _write_options(
         options_file,
         mapping_file,
-        **{MAPPING_UPLOAD_OPTION: _encoded_mapping(bad_mapping)},
+        **{MAPPING_UPLOAD_OPTION: _mapping_json(bad_mapping)},
     )
 
     with pytest.raises(ValueError, match="missing required keys: mapping"):

--- a/tests/test_haos_mapping_bootstrap.py
+++ b/tests/test_haos_mapping_bootstrap.py
@@ -1,0 +1,114 @@
+import base64
+import gzip
+import json
+
+import pytest
+
+from haos_mapping_bootstrap import (
+    MAPPING_UPLOAD_OPTION,
+    write_mapping_from_options,
+)
+
+
+def _mapping():
+    return {
+        "akahu_accounts": {},
+        "actual_accounts": {},
+        "ynab_accounts": {},
+        "mapping": {},
+    }
+
+
+def _encoded_mapping(data=None):
+    raw = json.dumps(data or _mapping()).encode("utf-8")
+    return base64.b64encode(gzip.compress(raw)).decode("ascii")
+
+
+def _write_options(path, mapping_file, **extra):
+    payload = {
+        "mapping_file": str(mapping_file),
+        **extra,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_no_upload_option_is_noop(tmp_path):
+    options_file = tmp_path / "options.json"
+    mapping_file = tmp_path / "akahu_budget_mapping.json"
+    _write_options(options_file, mapping_file)
+
+    assert write_mapping_from_options(options_file=options_file) is False
+    assert not mapping_file.exists()
+
+
+def test_valid_upload_writes_mapping_file(tmp_path):
+    options_file = tmp_path / "options.json"
+    mapping_file = tmp_path / "akahu_budget_mapping.json"
+    _write_options(
+        options_file,
+        mapping_file,
+        **{MAPPING_UPLOAD_OPTION: _encoded_mapping()},
+    )
+
+    assert write_mapping_from_options(options_file=options_file) is True
+    assert json.loads(mapping_file.read_text(encoding="utf-8")) == _mapping()
+    assert mapping_file.stat().st_mode & 0o777 == 0o600
+
+
+def test_existing_mapping_file_is_not_overwritten(tmp_path):
+    options_file = tmp_path / "options.json"
+    mapping_file = tmp_path / "akahu_budget_mapping.json"
+    existing = {"existing": True}
+    mapping_file.write_text(json.dumps(existing), encoding="utf-8")
+    _write_options(
+        options_file,
+        mapping_file,
+        **{MAPPING_UPLOAD_OPTION: _encoded_mapping()},
+    )
+
+    assert write_mapping_from_options(options_file=options_file) is False
+    assert json.loads(mapping_file.read_text(encoding="utf-8")) == existing
+
+
+def test_invalid_base64_fails(tmp_path):
+    options_file = tmp_path / "options.json"
+    mapping_file = tmp_path / "akahu_budget_mapping.json"
+    _write_options(options_file, mapping_file, **{MAPPING_UPLOAD_OPTION: "not base64"})
+
+    with pytest.raises(ValueError, match="not valid base64"):
+        write_mapping_from_options(options_file=options_file)
+
+
+def test_invalid_gzip_fails(tmp_path):
+    options_file = tmp_path / "options.json"
+    mapping_file = tmp_path / "akahu_budget_mapping.json"
+    encoded = base64.b64encode(b"not gzip").decode("ascii")
+    _write_options(options_file, mapping_file, **{MAPPING_UPLOAD_OPTION: encoded})
+
+    with pytest.raises(ValueError, match="not valid gzip"):
+        write_mapping_from_options(options_file=options_file)
+
+
+def test_invalid_json_fails(tmp_path):
+    options_file = tmp_path / "options.json"
+    mapping_file = tmp_path / "akahu_budget_mapping.json"
+    encoded = base64.b64encode(gzip.compress(b"{not-json")).decode("ascii")
+    _write_options(options_file, mapping_file, **{MAPPING_UPLOAD_OPTION: encoded})
+
+    with pytest.raises(ValueError, match="valid JSON"):
+        write_mapping_from_options(options_file=options_file)
+
+
+def test_missing_required_mapping_key_fails(tmp_path):
+    options_file = tmp_path / "options.json"
+    mapping_file = tmp_path / "akahu_budget_mapping.json"
+    bad_mapping = _mapping()
+    del bad_mapping["mapping"]
+    _write_options(
+        options_file,
+        mapping_file,
+        **{MAPPING_UPLOAD_OPTION: _encoded_mapping(bad_mapping)},
+    )
+
+    with pytest.raises(ValueError, match="missing required keys: mapping"):
+        write_mapping_from_options(options_file=options_file)


### PR DESCRIPTION
## Summary

- add a HAOS bootstrap helper that can create the add-on mapping file from a raw `mapping_json` Supervisor option when the file is missing
- expose `mapping_json` as a password-style add-on option and bump the HAOS add-on/image version to `0.1.1`
- document both setup paths: normal Home Assistant file tools and one-time raw JSON paste for MCP/automation setup

## Why

The current Home Assistant MCP tools can update add-on options and start the add-on, but they do not provide a generic file-write path into the add-on config volume. This gives automation a one-time mapping placement path without exposing SSH, without Base64/gzip indirection, and without printing secrets.

## Validation

- `pytest`