### PR TITLE
[codex] add HAOS changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}-haos
           tags: |
-            type=raw,value=0.1.1
+            type=raw,value=0.1.2
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push HAOS add-on image
@@ -67,7 +67,7 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            BUILD_VERSION=0.1.1
+            BUILD_VERSION=0.1.2
           push: true
           tags: ${{ steps.haos_meta.outputs.tags }}
           labels: ${{ steps.haos_meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM=python:3.12-alpine
 FROM $BUILD_FROM
-ARG BUILD_VERSION=0.1.1
+ARG BUILD_VERSION=0.1.2
 
 LABEL \
     io.hass.version="${BUILD_VERSION}" \

--- a/akahu_to_budget_addon/CHANGELOG.md
+++ b/akahu_to_budget_addon/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 0.1.2
+
+- Add Home Assistant add-on changelog metadata so the app store can display
+  release notes.
+- Clarify the add-on setup documentation around checking startup logs.
+
+## 0.1.1
+
+- Add a `mapping_json` option for one-time copy/paste or MCP-driven mapping
+  bootstrap.
+- Keep `mapping_json` as raw JSON and write it to `mapping_file` only when the
+  mapping file is missing.
+- Document the HAOS mapping setup paths.
+
+## 0.1.0
+
+- Add the initial Home Assistant OS add-on wrapper.
+- Publish the HAOS image as `ghcr.io/corrin/akahu_to_budget-haos`.

--- a/akahu_to_budget_addon/DOCS.md
+++ b/akahu_to_budget_addon/DOCS.md
@@ -32,7 +32,8 @@ repo root so this wrapper does not carry a separate copy of the sync code.
      The add-on writes this value to `mapping_file` only if the mapping file is
      missing. Clear `mapping_json` after the first successful start.
 3. Fill in the add-on options for Akahu and the enabled budget target.
-4. Start the add-on and watch the Supervisor log.
+4. Start the add-on and check its log in Home Assistant. It should print the
+   options file, mapping file, and sync interval before the first sync starts.
 
 Set `log_file` to an empty string for Supervisor-only logging. That is the
 default for this add-on.

--- a/akahu_to_budget_addon/config.yaml
+++ b/akahu_to_budget_addon/config.yaml
@@ -2,7 +2,7 @@ name: Akahu to Budget
 slug: akahu_to_budget
 description: Personal scheduled Akahu to Actual Budget/YNAB sync.
 url: https://github.com/corrin/akahu_to_budget
-version: "0.1.1"
+version: "0.1.2"
 image: ghcr.io/corrin/akahu_to_budget-haos
 stage: experimental
 startup: application


### PR DESCRIPTION
## Summary
- add an add-on `CHANGELOG.md` so Home Assistant can display release notes
- bump the HAOS add-on metadata/image tag to `0.1.2`
- clarify the add-on docs around checking startup logs

## Validation
- `pytest tests/test_haos_mapping_bootstrap.py`

## Notes
- This is a metadata/docs release only; no runtime sync behavior changes.