### PR TITLE
[codex] Schedule HAOS Akahu refresh before sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}-haos
           tags: |
-            type=raw,value=0.1.2
+            type=raw,value=0.1.3
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push HAOS add-on image
@@ -67,7 +67,7 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            BUILD_VERSION=0.1.2
+            BUILD_VERSION=0.1.3
           push: true
           tags: ${{ steps.haos_meta.outputs.tags }}
           labels: ${{ steps.haos_meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,14 @@ LABEL \
 
 WORKDIR /app/
 
-RUN apk add --no-cache bash jq
+RUN apk add --no-cache bash jq tzdata
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY modules ./modules
 COPY sync_cli.py .
+COPY haos_scheduler.py .
 COPY sure_client.py .
 COPY haos_mapping_bootstrap.py .
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Run the script using:
 # For one-time sync (recommended for most users):
 python sync_cli.py
 
+# Request Akahu refresh only:
+python sync_cli.py --refresh-only
+
+# Import without requesting another Akahu refresh:
+python sync_cli.py --skip-akahu-refresh
+
 # For running the webhook server:
 python flask_app.py
 ```
@@ -169,10 +175,10 @@ podman build -t akahu_to_budget:local -f Containerfile .
 
 This repo also includes a Home Assistant OS add-on wrapper in
 `akahu_to_budget_addon/`. It is intended for my personal HAOS setup: the add-on
-stays running and performs a scheduled daily sync by default because Akahu is
-synced daily. That automatic recurring sync is not necessarily the
-right behavior for everyone; the normal Python, Docker/Podman, cron, systemd,
-and Flask deployment paths remain supported.
+stays running, asks Akahu to refresh once per day, then imports into the enabled
+budget target later the same morning. That automatic recurring sync is not
+necessarily the right behavior for everyone; the normal Python, Docker/Podman,
+cron, systemd, and Flask deployment paths remain supported.
 
 The add-on uses the `ghcr.io/corrin/akahu_to_budget-haos` image, built from the
 repo root so it shares the same sync code as the other deployment methods.
@@ -250,7 +256,7 @@ the Home Assistant app store by adding this repository as an app repository.
    - Sure Finance settings, if enabled
 
 6. Start the app and check the app log. It should print the options file,
-   mapping file, and sync interval before the first sync starts.
+   mapping file, refresh time, and sync time before the scheduler starts.
 
 ## HAOS options
 
@@ -261,9 +267,23 @@ the mapping file at:
 /config/akahu_budget_mapping.json
 ```
 
-The default `sync_interval` is `86400`, which means one sync per day. Set
-`log_file` to an empty string to use Supervisor logs only; that is the default
-for the add-on.
+The HAOS scheduler defaults to:
+
+```yaml
+schedule_timezone: Pacific/Auckland
+refresh_time: "04:30"
+sync_time: "05:30"
+scheduler_state_file: /config/akahu_to_budget_state.json
+```
+
+At `refresh_time`, the add-on requests an Akahu refresh. At `sync_time`, it
+imports into the enabled budget target without requesting another refresh. The
+state file prevents a Home Assistant restart from causing a second sync on the
+same local day. `sync_interval` remains accepted for older option files, but the
+HAOS add-on schedule is controlled by `refresh_time` and `sync_time`.
+
+Set `log_file` to an empty string to use Supervisor logs only; that is the
+default for the add-on.
 
 `mapping_json` is optional and intended for automation or copy/paste setup. It
 is the raw contents of `akahu_budget_mapping.json`. The add-on uses it only when

--- a/akahu_to_budget_addon/CHANGELOG.md
+++ b/akahu_to_budget_addon/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.3
+
+- Request Akahu refresh at the configured daily refresh time, then import into
+  the enabled budget target at the configured sync time.
+- Persist scheduler state in the add-on config directory so restarts do not
+  trigger duplicate same-day syncs.
+- Add CLI flags for refresh-only and import-without-refresh runs.
+
 ## 0.1.2
 
 - Add Home Assistant add-on changelog metadata so the app store can display

--- a/akahu_to_budget_addon/DOCS.md
+++ b/akahu_to_budget_addon/DOCS.md
@@ -33,7 +33,21 @@ repo root so this wrapper does not carry a separate copy of the sync code.
      missing. Clear `mapping_json` after the first successful start.
 3. Fill in the add-on options for Akahu and the enabled budget target.
 4. Start the add-on and check its log in Home Assistant. It should print the
-   options file, mapping file, and sync interval before the first sync starts.
+   options file, mapping file, refresh time, and sync time before the scheduler
+   starts.
+
+## Schedule
+
+The add-on asks Akahu to refresh connected accounts once per local day, then
+imports into the enabled budget target later the same morning:
+
+- `refresh_time`: defaults to `04:30`
+- `sync_time`: defaults to `05:30`
+- `schedule_timezone`: defaults to `Pacific/Auckland`
+
+The scheduler persists its state in `scheduler_state_file`, which defaults to
+`/config/akahu_to_budget_state.json`. If Home Assistant restarts after a sync
+has completed, the add-on will not run the same daily sync again.
 
 Set `log_file` to an empty string for Supervisor-only logging. That is the
 default for this add-on.

--- a/akahu_to_budget_addon/config.yaml
+++ b/akahu_to_budget_addon/config.yaml
@@ -2,7 +2,7 @@ name: Akahu to Budget
 slug: akahu_to_budget
 description: Personal scheduled Akahu to Actual Budget/YNAB sync.
 url: https://github.com/corrin/akahu_to_budget
-version: "0.1.2"
+version: "0.1.3"
 image: ghcr.io/corrin/akahu_to_budget-haos
 stage: experimental
 startup: application
@@ -37,6 +37,10 @@ options:
   log_file: ""
   # Akahu is synced daily in this personal HAOS deployment.
   sync_interval: 86400
+  schedule_timezone: Pacific/Auckland
+  refresh_time: "04:30"
+  sync_time: "05:30"
+  scheduler_state_file: /config/akahu_to_budget_state.json
 schema:
   RUN_SYNC_TO_YNAB: bool
   RUN_SYNC_TO_AB: bool
@@ -60,3 +64,7 @@ schema:
   mapping_json: password?
   log_file: str
   sync_interval: int(1,)
+  schedule_timezone: str
+  refresh_time: str
+  sync_time: str
+  scheduler_state_file: str

--- a/haos_scheduler.py
+++ b/haos_scheduler.py
@@ -1,0 +1,74 @@
+"""CLI entrypoint for the Home Assistant OS daily scheduler."""
+
+import argparse
+import logging
+import signal
+import sys
+import time
+
+
+stop_requested = False
+
+
+def signal_handler(sig, frame):
+    global stop_requested
+    stop_requested = True
+    logging.info("Received signal to terminate scheduler. Shutting down gracefully...")
+
+
+def sleep_interruptibly(seconds):
+    remaining = max(0, int(seconds))
+    while remaining > 0 and not stop_requested:
+        chunk = min(remaining, 60)
+        time.sleep(chunk)
+        remaining -= chunk
+
+
+def main():
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    parser = argparse.ArgumentParser(
+        description="Run the Home Assistant OS daily Akahu scheduler."
+    )
+    parser.add_argument(
+        "--refresh-time",
+        help="Local HH:MM time to request Akahu refresh. Defaults to HA option refresh_time.",
+    )
+    parser.add_argument(
+        "--sync-time",
+        help="Local HH:MM time to import into budgets. Defaults to HA option sync_time.",
+    )
+    parser.add_argument(
+        "--schedule-timezone",
+        help="IANA timezone for refresh and sync times.",
+    )
+    parser.add_argument(
+        "--state-file",
+        help="Path for persisted scheduler state.",
+    )
+    args = parser.parse_args()
+
+    from modules.config import (
+        REFRESH_TIME,
+        SCHEDULE_TIMEZONE,
+        SCHEDULER_STATE_FILE,
+        SYNC_TIME,
+    )
+    from modules.haos_scheduler import SchedulerSettings, run_scheduler
+
+    settings = SchedulerSettings(
+        schedule_timezone=args.schedule_timezone or SCHEDULE_TIMEZONE,
+        refresh_time=args.refresh_time or REFRESH_TIME,
+        sync_time=args.sync_time or SYNC_TIME,
+        state_file=args.state_file or SCHEDULER_STATE_FILE,
+    )
+    run_scheduler(
+        settings,
+        sleeper=sleep_interruptibly,
+        stop_requested=lambda: stop_requested,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/config.py
+++ b/modules/config.py
@@ -19,6 +19,10 @@ DEFAULT_HA_OPTIONS_FILE = "/data/options.json"
 DEFAULT_MAPPING_FILE = "akahu_budget_mapping.json"
 DEFAULT_LOG_FILE = "app.log"
 DEFAULT_SYNC_INTERVAL = 86400
+DEFAULT_SCHEDULE_TIMEZONE = "Pacific/Auckland"
+DEFAULT_REFRESH_TIME = "04:30"
+DEFAULT_SYNC_TIME = "05:30"
+DEFAULT_SCHEDULER_STATE_FILE = "/config/akahu_to_budget_state.json"
 
 
 @dataclass(frozen=True)
@@ -31,6 +35,10 @@ class AppConfig:
     mapping_file: str
     log_file: str | None
     sync_interval: int
+    schedule_timezone: str
+    refresh_time: str
+    sync_time: str
+    scheduler_state_file: str
     envs: dict[str, str]
     akahu_endpoint: str = "https://api.akahu.io/v1"
     ynab_endpoint: str = "https://api.ynab.com/v1/"
@@ -69,6 +77,21 @@ def _optional_str(value):
     if value == "":
         return None
     return value
+
+
+def _validate_hhmm(value, key):
+    value = str(value).strip()
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise EnvironmentError(f"{key} must use HH:MM format")
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+    except ValueError as e:
+        raise EnvironmentError(f"{key} must use HH:MM format") from e
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59:
+        raise EnvironmentError(f"{key} must use HH:MM format")
+    return f"{hour:02d}:{minute:02d}"
 
 
 def _read_options_file(options_file, *, required):
@@ -187,6 +210,30 @@ def load_config(overrides=None, options_file=None):
     if sync_interval <= 0:
         raise EnvironmentError("SYNC_INTERVAL must be greater than zero")
 
+    schedule_timezone = _optional_str(
+        values.get("SCHEDULE_TIMEZONE", values.get("schedule_timezone"))
+    )
+    if schedule_timezone is None:
+        schedule_timezone = DEFAULT_SCHEDULE_TIMEZONE
+
+    refresh_time = _validate_hhmm(
+        values.get("REFRESH_TIME", values.get("refresh_time", DEFAULT_REFRESH_TIME)),
+        "REFRESH_TIME",
+    )
+    sync_time = _validate_hhmm(
+        values.get("SYNC_TIME", values.get("sync_time", DEFAULT_SYNC_TIME)),
+        "SYNC_TIME",
+    )
+
+    scheduler_state_file = _optional_str(
+        values.get(
+            "SCHEDULER_STATE_FILE",
+            values.get("scheduler_state_file", DEFAULT_SCHEDULER_STATE_FILE),
+        )
+    )
+    if scheduler_state_file is None:
+        scheduler_state_file = DEFAULT_SCHEDULER_STATE_FILE
+
     mapping_file = _optional_str(values.get("MAPPING_FILE", values.get("mapping_file")))
     log_file = _optional_str(
         values.get("LOG_FILE", values.get("log_file", DEFAULT_LOG_FILE))
@@ -203,6 +250,10 @@ def load_config(overrides=None, options_file=None):
         mapping_file=mapping_file,
         log_file=log_file,
         sync_interval=sync_interval,
+        schedule_timezone=schedule_timezone,
+        refresh_time=refresh_time,
+        sync_time=sync_time,
+        scheduler_state_file=scheduler_state_file,
         envs=envs,
     )
 
@@ -217,6 +268,10 @@ DEBUG_SYNC = CONFIG.debug_sync
 MAPPING_FILE = CONFIG.mapping_file
 LOG_FILE = CONFIG.log_file
 SYNC_INTERVAL = CONFIG.sync_interval
+SCHEDULE_TIMEZONE = CONFIG.schedule_timezone
+REFRESH_TIME = CONFIG.refresh_time
+SYNC_TIME = CONFIG.sync_time
+SCHEDULER_STATE_FILE = CONFIG.scheduler_state_file
 ENVs = CONFIG.envs
 
 AKAHU_ENDPOINT = CONFIG.akahu_endpoint

--- a/modules/haos_scheduler.py
+++ b/modules/haos_scheduler.py
@@ -1,0 +1,241 @@
+"""Home Assistant OS daily scheduler for Akahu refresh and budget sync."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, date, time, timedelta
+import json
+import logging
+from pathlib import Path
+import time as time_module
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from modules.sync_runner import configure_logging, refresh_akahu, run_sync
+
+
+LAST_REFRESH_DATE = "last_refresh_requested_local_date"
+LAST_REFRESH_AT = "last_refresh_requested_at"
+LAST_SYNC_DATE = "last_sync_completed_local_date"
+
+
+@dataclass(frozen=True)
+class SchedulerSettings:
+    schedule_timezone: str
+    refresh_time: str
+    sync_time: str
+    state_file: str
+    retry_refresh_seconds: int = 900
+    retry_sync_seconds: int = 3600
+
+    @property
+    def zone(self):
+        try:
+            return ZoneInfo(self.schedule_timezone)
+        except ZoneInfoNotFoundError as e:
+            raise EnvironmentError(
+                f"Unknown schedule timezone: {self.schedule_timezone}"
+            ) from e
+
+    @property
+    def refresh_clock(self):
+        return parse_hhmm(self.refresh_time, "refresh_time")
+
+    @property
+    def sync_clock(self):
+        return parse_hhmm(self.sync_time, "sync_time")
+
+    @property
+    def refresh_to_sync_gap(self):
+        today = date(2000, 1, 1)
+        refresh_dt = datetime.combine(today, self.refresh_clock)
+        sync_dt = datetime.combine(today, self.sync_clock)
+        if sync_dt > refresh_dt:
+            return sync_dt - refresh_dt
+        return timedelta(hours=1)
+
+
+@dataclass(frozen=True)
+class SchedulerDecision:
+    action: str
+    delay_seconds: int
+    reason: str
+
+
+def parse_hhmm(value, key):
+    parts = str(value).strip().split(":")
+    if len(parts) != 2:
+        raise ValueError(f"{key} must use HH:MM format")
+    hour = int(parts[0])
+    minute = int(parts[1])
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59:
+        raise ValueError(f"{key} must use HH:MM format")
+    return time(hour=hour, minute=minute)
+
+
+def read_state(path):
+    state_path = Path(path)
+    if not state_path.exists():
+        return {}
+    try:
+        with state_path.open("r", encoding="utf-8") as f:
+            state = json.load(f)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Invalid scheduler state file {state_path}: {e}") from e
+    if not isinstance(state, dict):
+        raise RuntimeError(f"Scheduler state file {state_path} must contain an object")
+    return state
+
+
+def write_state(path, state):
+    state_path = Path(path)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with state_path.open("w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def seconds_until(target, now):
+    return max(0, int((target - now).total_seconds()))
+
+
+def local_day(now):
+    return now.date().isoformat()
+
+
+def at_local(day, clock, zone):
+    return datetime.combine(day, clock, tzinfo=zone)
+
+
+def parse_datetime(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def decide_next_action(now, state, settings):
+    zone = settings.zone
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=zone)
+    else:
+        now = now.astimezone(zone)
+
+    today = now.date()
+    today_key = today.isoformat()
+    tomorrow = today + timedelta(days=1)
+
+    refresh_at = at_local(today, settings.refresh_clock, zone)
+    next_refresh_at = at_local(tomorrow, settings.refresh_clock, zone)
+
+    if state.get(LAST_SYNC_DATE) == today_key:
+        return SchedulerDecision(
+            "sleep",
+            seconds_until(next_refresh_at, now),
+            "sync already completed today",
+        )
+
+    if state.get(LAST_REFRESH_DATE) != today_key:
+        if now >= refresh_at:
+            return SchedulerDecision("refresh", 0, "daily refresh is due")
+        return SchedulerDecision(
+            "sleep", seconds_until(refresh_at, now), "waiting for daily refresh time"
+        )
+
+    sync_at = at_local(today, settings.sync_clock, zone)
+    last_refresh_at = parse_datetime(state.get(LAST_REFRESH_AT))
+    if last_refresh_at is not None:
+        last_refresh_at = last_refresh_at.astimezone(zone)
+        sync_at = max(sync_at, last_refresh_at + settings.refresh_to_sync_gap)
+
+    if now >= sync_at:
+        return SchedulerDecision("sync", 0, "daily sync is due")
+    return SchedulerDecision(
+        "sleep", seconds_until(sync_at, now), "waiting for daily sync time"
+    )
+
+
+def mark_refresh_complete(state, now):
+    updated = dict(state)
+    updated[LAST_REFRESH_DATE] = local_day(now)
+    updated[LAST_REFRESH_AT] = now.isoformat()
+    return updated
+
+
+def mark_sync_complete(state, now):
+    updated = dict(state)
+    updated[LAST_SYNC_DATE] = local_day(now)
+    updated["last_sync_completed_at"] = now.isoformat()
+    return updated
+
+
+def run_scheduler(
+    settings,
+    *,
+    now_fn=None,
+    sleeper=None,
+    refresh_fn=None,
+    sync_fn=None,
+    stop_requested=None,
+):
+    configure_logging()
+    now_fn = now_fn or (lambda: datetime.now(settings.zone))
+    sleeper = sleeper or time_module.sleep
+    refresh_fn = refresh_fn or refresh_akahu
+    sync_fn = sync_fn or (lambda: run_sync(skip_akahu_refresh=True))
+    stop_requested = stop_requested or (lambda: False)
+
+    logging.info(
+        "Starting HAOS scheduler: refresh %s, sync %s, timezone %s, state %s",
+        settings.refresh_time,
+        settings.sync_time,
+        settings.schedule_timezone,
+        settings.state_file,
+    )
+
+    while not stop_requested():
+        state = read_state(settings.state_file)
+        now = now_fn().astimezone(settings.zone)
+        decision = decide_next_action(now, state, settings)
+
+        if decision.action == "sleep":
+            logging.info(
+                "Scheduler sleeping %ss: %s",
+                decision.delay_seconds,
+                decision.reason,
+            )
+            sleeper(decision.delay_seconds)
+            continue
+
+        if decision.action == "refresh":
+            logging.info("Running scheduled Akahu refresh: %s", decision.reason)
+            try:
+                refresh_fn()
+            except Exception as e:
+                logging.warning(
+                    "Scheduled Akahu refresh failed; retrying in %ss: %s",
+                    settings.retry_refresh_seconds,
+                    e,
+                )
+                sleeper(settings.retry_refresh_seconds)
+                continue
+            write_state(settings.state_file, mark_refresh_complete(state, now))
+            continue
+
+        if decision.action == "sync":
+            logging.info("Running scheduled budget sync: %s", decision.reason)
+            try:
+                sync_fn()
+            except Exception as e:
+                logging.warning(
+                    "Scheduled budget sync failed; retrying in %ss: %s",
+                    settings.retry_sync_seconds,
+                    e,
+                )
+                sleeper(settings.retry_sync_seconds)
+                continue
+            write_state(settings.state_file, mark_sync_complete(state, now))
+            continue
+
+        raise RuntimeError(f"Unknown scheduler action: {decision.action}")

--- a/modules/sync_runner.py
+++ b/modules/sync_runner.py
@@ -131,12 +131,21 @@ def sync_to_sure(mapping_list):
     return sure_count
 
 
-def run_sync(account_ids=None, debug_mode=None):
+def refresh_akahu():
+    """Request Akahu to refresh connected accounts."""
+    logging.info("Requesting Akahu refresh...")
+    trigger_akahu_refresh()
+
+
+def run_sync(account_ids=None, debug_mode=None, *, skip_akahu_refresh=False):
     """Run Akahu sync to enabled budget targets."""
     logging.info("Starting direct sync...")
     actual_count = ynab_count = sure_count = 0
 
-    trigger_akahu_refresh()
+    if skip_akahu_refresh:
+        logging.info("Skipping Akahu refresh before import.")
+    else:
+        refresh_akahu()
 
     _, _, _, mapping_list = load_existing_mapping(MAPPING_FILE)
 

--- a/run.sh
+++ b/run.sh
@@ -31,7 +31,9 @@ fi
 export AKAHU_TO_BUDGET_OPTIONS_FILE="$OPTIONS_FILE"
 
 MAPPING_FILE=$(jq -r '.mapping_file // "/config/akahu_budget_mapping.json"' "$OPTIONS_FILE")
-SYNC_INTERVAL=$(jq -r '.sync_interval // 86400' "$OPTIONS_FILE")
+REFRESH_TIME=$(jq -r '.refresh_time // "04:30"' "$OPTIONS_FILE")
+SYNC_TIME=$(jq -r '.sync_time // "05:30"' "$OPTIONS_FILE")
+SCHEDULE_TIMEZONE=$(jq -r '.schedule_timezone // "Pacific/Auckland"' "$OPTIONS_FILE")
 
 python /app/haos_mapping_bootstrap.py
 
@@ -44,12 +46,8 @@ fi
 echo "Using Home Assistant options from $OPTIONS_FILE"
 echo "Using mapping file $MAPPING_FILE"
 
-echo "Sync interval: ${SYNC_INTERVAL}s"
-echo "Starting sync loop..."
+echo "Refresh time: ${REFRESH_TIME} ${SCHEDULE_TIMEZONE}"
+echo "Sync time: ${SYNC_TIME} ${SCHEDULE_TIMEZONE}"
+echo "Starting scheduler..."
 
-while true; do
-    echo "=== Sync started at $(date -u) ==="
-    run_interruptible python /app/sync_cli.py || echo "Sync failed; retrying in ${SYNC_INTERVAL}s"
-    echo "=== Sync finished; sleeping ${SYNC_INTERVAL}s ==="
-    run_interruptible sleep "$SYNC_INTERVAL"
-done
+run_interruptible python /app/haos_scheduler.py

--- a/sync_cli.py
+++ b/sync_cli.py
@@ -52,17 +52,38 @@ def main():
             "Use an empty string to log to stdout only."
         ),
     )
+    parser.add_argument(
+        "--refresh-only",
+        action="store_true",
+        help="Trigger an Akahu refresh request and exit without importing transactions.",
+    )
+    parser.add_argument(
+        "--skip-akahu-refresh",
+        action="store_true",
+        help="Import transactions without first triggering an Akahu refresh.",
+    )
     args = parser.parse_args()
+
+    if args.refresh_only and args.skip_akahu_refresh:
+        parser.error("--refresh-only cannot be used with --skip-akahu-refresh")
 
     set_env_override("MAPPING_FILE", args.mapping_file)
     set_env_override("LOG_FILE", args.log_file)
 
-    from modules.sync_runner import configure_logging, run_sync
+    from modules.sync_runner import configure_logging, refresh_akahu, run_sync
 
     configure_logging()
 
+    if args.refresh_only:
+        refresh_akahu()
+        return
+
     account_ids = args.accounts.split(",") if args.accounts else None
-    run_sync(account_ids, debug_mode=args.debug)
+    run_sync(
+        account_ids,
+        debug_mode=args.debug,
+        skip_akahu_refresh=args.skip_akahu_refresh,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,10 @@ def clean_env(monkeypatch):
         "MAPPING_FILE",
         "LOG_FILE",
         "SYNC_INTERVAL",
+        "SCHEDULE_TIMEZONE",
+        "REFRESH_TIME",
+        "SYNC_TIME",
+        "SCHEDULER_STATE_FILE",
         "AKAHU_TO_BUDGET_OPTIONS_FILE",
     ]
     for k in keys:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,18 +119,30 @@ def test_mapping_log_paths_and_daily_sync_default_for_existing_deployments(
     assert cfg.MAPPING_FILE == "akahu_budget_mapping.json"
     assert cfg.LOG_FILE == "app.log"
     assert cfg.SYNC_INTERVAL == 86400
+    assert cfg.SCHEDULE_TIMEZONE == "Pacific/Auckland"
+    assert cfg.REFRESH_TIME == "04:30"
+    assert cfg.SYNC_TIME == "05:30"
+    assert cfg.SCHEDULER_STATE_FILE == "/config/akahu_to_budget_state.json"
 
 
 def test_env_can_override_mapping_log_and_interval(full_env, reload_config):
     full_env.setenv("MAPPING_FILE", "/tmp/custom-mapping.json")
     full_env.setenv("LOG_FILE", "")
     full_env.setenv("SYNC_INTERVAL", "300")
+    full_env.setenv("SCHEDULE_TIMEZONE", "UTC")
+    full_env.setenv("REFRESH_TIME", "03:05")
+    full_env.setenv("SYNC_TIME", "04:15")
+    full_env.setenv("SCHEDULER_STATE_FILE", "/tmp/state.json")
 
     cfg = reload_config()
 
     assert cfg.MAPPING_FILE == "/tmp/custom-mapping.json"
     assert cfg.LOG_FILE is None
     assert cfg.SYNC_INTERVAL == 300
+    assert cfg.SCHEDULE_TIMEZONE == "UTC"
+    assert cfg.REFRESH_TIME == "03:05"
+    assert cfg.SYNC_TIME == "04:15"
+    assert cfg.SCHEDULER_STATE_FILE == "/tmp/state.json"
 
 
 def test_home_assistant_options_override_env(clean_env, reload_config, tmp_path):
@@ -150,6 +162,10 @@ def test_home_assistant_options_override_env(clean_env, reload_config, tmp_path)
                 "mapping_file": "/data/akahu_budget_mapping.json",
                 "log_file": "",
                 "sync_interval": 600,
+                "schedule_timezone": "UTC",
+                "refresh_time": "04:30",
+                "sync_time": "05:30",
+                "scheduler_state_file": "/data/scheduler-state.json",
             }
         ),
         encoding="utf-8",
@@ -167,6 +183,17 @@ def test_home_assistant_options_override_env(clean_env, reload_config, tmp_path)
     assert cfg.MAPPING_FILE == "/data/akahu_budget_mapping.json"
     assert cfg.LOG_FILE is None
     assert cfg.SYNC_INTERVAL == 600
+    assert cfg.SCHEDULE_TIMEZONE == "UTC"
+    assert cfg.REFRESH_TIME == "04:30"
+    assert cfg.SYNC_TIME == "05:30"
+    assert cfg.SCHEDULER_STATE_FILE == "/data/scheduler-state.json"
+
+
+def test_invalid_scheduler_time_fails_loud(full_env, reload_config):
+    full_env.setenv("REFRESH_TIME", "25:00")
+
+    with pytest.raises(EnvironmentError, match="REFRESH_TIME"):
+        reload_config()
 
 
 def test_invalid_home_assistant_options_json_fails_loud(clean_env, reload_config, tmp_path):

--- a/tests/test_haos_scheduler.py
+++ b/tests/test_haos_scheduler.py
@@ -1,0 +1,121 @@
+"""Tests for the Home Assistant OS daily scheduler decisions."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _env(clean_env, reload_config):
+    clean_env.setenv("RUN_SYNC_TO_YNAB", "true")
+    clean_env.setenv("RUN_SYNC_TO_AB", "false")
+    clean_env.setenv("AKAHU_USER_TOKEN", "akahu-user")
+    clean_env.setenv("AKAHU_APP_TOKEN", "akahu-app")
+    clean_env.setenv("YNAB_BEARER_TOKEN", "ynab-bearer")
+    reload_config()
+
+
+@pytest.fixture
+def settings(tmp_path):
+    from modules.haos_scheduler import SchedulerSettings
+
+    return SchedulerSettings(
+        schedule_timezone="Pacific/Auckland",
+        refresh_time="04:30",
+        sync_time="05:30",
+        state_file=str(tmp_path / "state.json"),
+    )
+
+
+def local_dt(hour, minute):
+    return datetime(2026, 6, 7, hour, minute, tzinfo=ZoneInfo("Pacific/Auckland"))
+
+
+def test_waits_until_refresh_time(settings):
+    from modules.haos_scheduler import decide_next_action
+
+    decision = decide_next_action(local_dt(4, 0), {}, settings)
+
+    assert decision.action == "sleep"
+    assert decision.delay_seconds == 1800
+    assert "refresh" in decision.reason
+
+
+def test_refresh_is_due_once_time_passed(settings):
+    from modules.haos_scheduler import decide_next_action
+
+    decision = decide_next_action(local_dt(4, 30), {}, settings)
+
+    assert decision.action == "refresh"
+
+
+def test_restart_after_refresh_waits_for_sync_time(settings):
+    from modules.haos_scheduler import (
+        LAST_REFRESH_AT,
+        LAST_REFRESH_DATE,
+        decide_next_action,
+    )
+
+    state = {
+        LAST_REFRESH_DATE: "2026-06-07",
+        LAST_REFRESH_AT: local_dt(4, 30).isoformat(),
+    }
+
+    decision = decide_next_action(local_dt(5, 0), state, settings)
+
+    assert decision.action == "sleep"
+    assert decision.delay_seconds == 1800
+    assert "sync" in decision.reason
+
+
+def test_sync_is_due_after_refresh_gap(settings):
+    from modules.haos_scheduler import (
+        LAST_REFRESH_AT,
+        LAST_REFRESH_DATE,
+        decide_next_action,
+    )
+
+    state = {
+        LAST_REFRESH_DATE: "2026-06-07",
+        LAST_REFRESH_AT: local_dt(4, 30).isoformat(),
+    }
+
+    decision = decide_next_action(local_dt(5, 30), state, settings)
+
+    assert decision.action == "sync"
+
+
+def test_late_start_waits_gap_after_immediate_refresh(settings):
+    from modules.haos_scheduler import decide_next_action, mark_refresh_complete
+
+    refreshed_state = mark_refresh_complete({}, local_dt(10, 0))
+
+    decision = decide_next_action(local_dt(10, 15), refreshed_state, settings)
+
+    assert decision.action == "sleep"
+    assert decision.delay_seconds == 2700
+
+
+def test_completed_sync_sleeps_until_tomorrow_refresh(settings):
+    from modules.haos_scheduler import LAST_SYNC_DATE, decide_next_action
+
+    decision = decide_next_action(
+        local_dt(6, 0),
+        {LAST_SYNC_DATE: "2026-06-07"},
+        settings,
+    )
+
+    assert decision.action == "sleep"
+    assert decision.delay_seconds == 81000
+
+
+def test_state_round_trip(tmp_path):
+    from modules.haos_scheduler import read_state, write_state
+
+    state_file = tmp_path / "scheduler.json"
+    write_state(str(state_file), {"last_sync_completed_local_date": "2026-06-07"})
+
+    assert read_state(str(state_file)) == {
+        "last_sync_completed_local_date": "2026-06-07"
+    }

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -1,5 +1,8 @@
 """Tests for sync_cli argument helpers."""
 
+import sys
+from unittest.mock import Mock
+
 
 def test_set_env_override_ignores_missing_value(monkeypatch):
     from sync_cli import set_env_override
@@ -17,3 +20,77 @@ def test_set_env_override_preserves_empty_string(monkeypatch):
     set_env_override("LOG_FILE", "")
 
     assert __import__("os").environ["LOG_FILE"] == ""
+
+
+def test_refresh_only_calls_refresh_and_skips_sync(clean_env, reload_config, monkeypatch):
+    clean_env.setenv("RUN_SYNC_TO_YNAB", "true")
+    clean_env.setenv("RUN_SYNC_TO_AB", "false")
+    clean_env.setenv("AKAHU_USER_TOKEN", "akahu-user")
+    clean_env.setenv("AKAHU_APP_TOKEN", "akahu-app")
+    clean_env.setenv("YNAB_BEARER_TOKEN", "ynab-bearer")
+    reload_config()
+    import modules.sync_runner as sync_runner
+    from sync_cli import main
+
+    refresh = Mock()
+    run_sync = Mock()
+    monkeypatch.setattr(sync_runner, "refresh_akahu", refresh)
+    monkeypatch.setattr(sync_runner, "run_sync", run_sync)
+    monkeypatch.setattr(sys, "argv", ["sync_cli.py", "--refresh-only"])
+
+    main()
+
+    refresh.assert_called_once_with()
+    run_sync.assert_not_called()
+
+
+def test_skip_akahu_refresh_passes_through(clean_env, reload_config, monkeypatch):
+    clean_env.setenv("RUN_SYNC_TO_YNAB", "true")
+    clean_env.setenv("RUN_SYNC_TO_AB", "false")
+    clean_env.setenv("AKAHU_USER_TOKEN", "akahu-user")
+    clean_env.setenv("AKAHU_APP_TOKEN", "akahu-app")
+    clean_env.setenv("YNAB_BEARER_TOKEN", "ynab-bearer")
+    reload_config()
+    import modules.sync_runner as sync_runner
+    from sync_cli import main
+
+    refresh = Mock()
+    run_sync = Mock()
+    monkeypatch.setattr(sync_runner, "refresh_akahu", refresh)
+    monkeypatch.setattr(sync_runner, "run_sync", run_sync)
+    monkeypatch.setattr(sys, "argv", ["sync_cli.py", "--skip-akahu-refresh"])
+
+    main()
+
+    refresh.assert_not_called()
+    run_sync.assert_called_once_with(
+        None,
+        debug_mode=None,
+        skip_akahu_refresh=True,
+    )
+
+
+def test_default_cli_still_refreshes_before_sync(clean_env, reload_config, monkeypatch):
+    clean_env.setenv("RUN_SYNC_TO_YNAB", "true")
+    clean_env.setenv("RUN_SYNC_TO_AB", "false")
+    clean_env.setenv("AKAHU_USER_TOKEN", "akahu-user")
+    clean_env.setenv("AKAHU_APP_TOKEN", "akahu-app")
+    clean_env.setenv("YNAB_BEARER_TOKEN", "ynab-bearer")
+    reload_config()
+    import modules.sync_runner as sync_runner
+    from sync_cli import main
+
+    refresh = Mock()
+    run_sync = Mock()
+    monkeypatch.setattr(sync_runner, "refresh_akahu", refresh)
+    monkeypatch.setattr(sync_runner, "run_sync", run_sync)
+    monkeypatch.setattr(sys, "argv", ["sync_cli.py"])
+
+    main()
+
+    refresh.assert_not_called()
+    run_sync.assert_called_once_with(
+        None,
+        debug_mode=None,
+        skip_akahu_refresh=False,
+    )


### PR DESCRIPTION
## Summary

- replace the HAOS add-on sleep loop with a persisted daily scheduler
- request Akahu refresh at 04:30 Pacific/Auckland and import at 05:30 by default
- add CLI flags for refresh-only and import-without-refresh runs
- preserve the no-flag CLI behavior for non-HAOS users
- bump the HAOS add-on/image version to 0.1.3 for deployment

## Validation

- `./.venv/bin/python -m pytest` -> 72 passed, 4 existing datetime.utcnow deprecation warnings
- `./.venv/bin/python sync_cli.py --help`
- `./.venv/bin/python haos_scheduler.py --help`