### PR TITLE
[codex] fix HAOS scheduler boundary sleep

### DIFF
--- a/modules/haos_scheduler.py
+++ b/modules/haos_scheduler.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, date, time, timedelta
 import json
 import logging
+import math
 from pathlib import Path
 import time as time_module
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -95,7 +96,7 @@ def write_state(path, state):
 
 
 def seconds_until(target, now):
-    return max(0, int((target - now).total_seconds()))
+    return max(0, math.ceil((target - now).total_seconds()))
 
 
 def local_day(now):

--- a/tests/test_haos_scheduler.py
+++ b/tests/test_haos_scheduler.py
@@ -69,6 +69,37 @@ def test_restart_after_refresh_waits_for_sync_time(settings):
     assert "sync" in decision.reason
 
 
+def test_subsecond_wait_before_sync_does_not_spin(settings):
+    from modules.haos_scheduler import (
+        LAST_REFRESH_AT,
+        LAST_REFRESH_DATE,
+        decide_next_action,
+    )
+
+    state = {
+        LAST_REFRESH_DATE: "2026-06-07",
+        LAST_REFRESH_AT: local_dt(4, 30).isoformat(),
+    }
+
+    decision = decide_next_action(
+        datetime(
+            2026,
+            6,
+            7,
+            5,
+            29,
+            59,
+            900000,
+            tzinfo=ZoneInfo("Pacific/Auckland"),
+        ),
+        state,
+        settings,
+    )
+
+    assert decision.action == "sleep"
+    assert decision.delay_seconds == 1
+
+
 def test_sync_is_due_after_refresh_gap(settings):
     from modules.haos_scheduler import (
         LAST_REFRESH_AT,


### PR DESCRIPTION
## Summary
- round scheduler sleep delays up instead of down so sub-second waits do not become zero-second loops
- add a regression test for the 05:29:59.900 boundary before the scheduled HAOS sync

## Root cause
The live HAOS logs showed repeated  entries immediately before the 05:30 sync.  truncated fractional seconds with , and the CLI sleep wrapper treats zero as no sleep.

## Validation
- ........                                                                 [100%]
8 passed in 0.51s
- ........................................................................ [ 98%]
.                                                                        [100%]
=============================== warnings summary ===============================
tests/test_transaction_handler.py::test_rule_setting_transfer_payee_triggers_set_transaction_payee
tests/test_transaction_handler.py::test_payee_id_is_reverted_before_calling_set_transaction_payee
tests/test_transaction_handler.py::test_rule_setting_non_transfer_payee_does_not_call_set_transaction_payee
tests/test_transaction_handler.py::test_rule_not_changing_payee_does_not_call_set_transaction_payee
  /home/corrin/src/akahu_to_budget/modules/transaction_handler.py:397: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    mapping_entry["actual_synced_datetime"] = datetime.utcnow().strftime(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
73 passed, 4 warnings in 1.73s