### PR TITLE
[codex] Improve Actual import metadata

### DIFF
--- a/modules/sync_runner.py
+++ b/modules/sync_runner.py
@@ -59,6 +59,13 @@ def get_actual_client():
                 encryption_password=ENVs["ACTUAL_ENCRYPTION_KEY"],
             ) as client:
                 logging.info(f"Connected to AB: {client}")
+                info = client.info()
+                build = getattr(info, "build", None)
+                server_name = getattr(build, "name", "Actual Budget")
+                server_version = getattr(build, "version", None) or "unknown"
+                logging.info(
+                    f"Actual server info: {server_name} version {server_version}"
+                )
                 yield client
         except (httpx.HTTPError, requests.exceptions.RequestException) as e:
             logging.error(f"Failed to connect to Actual server: {str(e)}")

--- a/modules/transaction_handler.py
+++ b/modules/transaction_handler.py
@@ -216,8 +216,8 @@ def load_transactions_into_actual(transactions, mapping_entry, actual, debug_mod
 
     for _, txn in transactions.iterrows():
         transaction_date = txn.get("date")
-        payee_name = txn.get("description")
-        notes = txn.get("description")
+        payee_name = get_payee_name(txn)
+        notes = format_transaction_notes(txn)
         imported_id = txn.get("_id")
         raw_amount = txn.get("amount")
         try:
@@ -515,6 +515,27 @@ def get_payee_name(row):
         logging.error(f"Error extracting payee name from row: {e}, row: {row}")
         res = "Unknown"
     return res
+
+
+def format_transaction_notes(row):
+    """Build Actual notes from useful Akahu context without empty separators."""
+    parts = []
+
+    transaction_type = row.get("type")
+    if transaction_type:
+        parts.append(str(transaction_type))
+
+    category = row.get("category")
+    if isinstance(category, dict):
+        category_name = category.get("name")
+        if category_name:
+            parts.append(str(category_name))
+
+    description = row.get("description")
+    if description:
+        parts.append(str(description))
+
+    return " | ".join(parts)
 
 
 def convert_to_nzt(date_str):

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -1,0 +1,38 @@
+"""Tests for shared sync runner behavior."""
+
+import importlib
+import logging
+from types import SimpleNamespace
+
+
+def test_actual_client_logs_server_info(full_env, reload_config, monkeypatch, caplog):
+    reload_config()
+
+    import actual
+    import modules.sync_runner as sync_runner
+
+    sync_runner = importlib.reload(sync_runner)
+
+    fake_client = SimpleNamespace(
+        info=lambda: SimpleNamespace(
+            build=SimpleNamespace(name="Actual Budget", version="26.5.0")
+        )
+    )
+
+    class FakeActual:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def __enter__(self):
+            return fake_client
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(actual, "Actual", FakeActual)
+
+    with caplog.at_level(logging.INFO):
+        with sync_runner.get_actual_client() as client:
+            assert client is fake_client
+
+    assert "Actual server info: Actual Budget version 26.5.0" in caplog.text

--- a/tests/test_transaction_handler.py
+++ b/tests/test_transaction_handler.py
@@ -83,6 +83,96 @@ def test_error_distinguishes_empty_string_from_garbage(mocker):
     assert str(exc_empty.value) != str(exc_abc.value)
 
 
+def test_actual_import_prefers_merchant_name_for_payee(mocker):
+    from modules import transaction_handler
+
+    mocker.patch.object(
+        transaction_handler, "get_cached_names", return_value=({}, {})
+    )
+    mocker.patch.object(transaction_handler, "get_ruleset", return_value=None)
+
+    fake_txn = mocker.MagicMock()
+    fake_txn.changed.side_effect = [True, True]
+    reconcile = mocker.patch.object(
+        transaction_handler, "reconcile_transaction", return_value=fake_txn
+    )
+
+    fake_actual = mocker.MagicMock()
+    fake_actual.session = mocker.MagicMock()
+    df = pd.DataFrame(
+        [
+            {
+                "_id": "trans_merchant",
+                "amount": -7.5,
+                "date": "2025-05-26T04:00:00Z",
+                "description": "EFTPOS PURCHASE 1234",
+                "merchant": {"name": "Coffee Supreme"},
+                "type": "debit",
+                "category": {"name": "Food and Drink"},
+            }
+        ]
+    )
+
+    transaction_handler.load_transactions_into_actual(
+        df, {"actual_account_id": "actual-acc-1"}, fake_actual
+    )
+
+    assert reconcile.call_args.kwargs["payee"] == "Coffee Supreme"
+    assert reconcile.call_args.kwargs["imported_payee"] == "Coffee Supreme"
+
+
+def test_actual_import_falls_back_to_description_and_formats_notes(mocker):
+    from modules import transaction_handler
+
+    mocker.patch.object(
+        transaction_handler, "get_cached_names", return_value=({}, {})
+    )
+    mocker.patch.object(transaction_handler, "get_ruleset", return_value=None)
+
+    fake_txn = mocker.MagicMock()
+    fake_txn.changed.side_effect = [True, True]
+    reconcile = mocker.patch.object(
+        transaction_handler, "reconcile_transaction", return_value=fake_txn
+    )
+
+    fake_actual = mocker.MagicMock()
+    fake_actual.session = mocker.MagicMock()
+    df = pd.DataFrame(
+        [
+            {
+                "_id": "trans_description",
+                "amount": -12.0,
+                "date": "2025-05-26T04:00:00Z",
+                "description": "Countdown Auckland",
+                "merchant": None,
+                "type": "debit",
+                "category": {"name": "Groceries"},
+            }
+        ]
+    )
+
+    transaction_handler.load_transactions_into_actual(
+        df, {"actual_account_id": "actual-acc-1"}, fake_actual
+    )
+
+    assert reconcile.call_args.kwargs["payee"] == "Countdown Auckland"
+    assert reconcile.call_args.kwargs["notes"] == (
+        "debit | Groceries | Countdown Auckland"
+    )
+
+
+def test_actual_notes_omit_missing_context_without_empty_separators():
+    from modules.transaction_handler import format_transaction_notes
+
+    assert format_transaction_notes(
+        {
+            "type": "",
+            "category": {},
+            "description": "ATM Withdrawal",
+        }
+    ) == "ATM Withdrawal"
+
+
 # --- ruleset-driven transfer payees should materialise the mirror transaction ---
 
 


### PR DESCRIPTION
## Summary

- use Akahu `merchant.name` as the Actual payee when available, falling back to the original description
- enrich Actual transaction notes with Akahu type/category/description context
- log Actual server name/version during client startup via `actual_client.info()`
- add focused tests for payee selection, note formatting, and server-info logging

Thanks @scottmckendry for the ideas from `scottmckendry/akahu-actual`.

## Validation

- `./.venv/bin/python -m pytest` - 77 passed, 6 existing `datetime.utcnow()` deprecation warnings